### PR TITLE
Python3 support added initially

### DIFF
--- a/mezzanine_blocks/admin.py
+++ b/mezzanine_blocks/admin.py
@@ -3,7 +3,7 @@ from functools import partial
 from django.utils.translation import ugettext_lazy as _
 from django.contrib import admin
 from mezzanine.conf import settings
-from models import BlockCategory, Block, RichBlock, ImageBlock
+from .models import BlockCategory, Block, RichBlock, ImageBlock
 
 
 class BlockCategoryAdmin(admin.ModelAdmin):

--- a/mezzanine_blocks/forms.py
+++ b/mezzanine_blocks/forms.py
@@ -1,5 +1,5 @@
 from django.forms import ModelForm
-from models import Block
+from .models import Block
 
 
 class BlockForm(ModelForm):

--- a/mezzanine_blocks/templatetags/block_tags.py
+++ b/mezzanine_blocks/templatetags/block_tags.py
@@ -46,7 +46,7 @@ class BasicFlatBlockWrapper(object):
             self.cache_time = args[0]
             self.tpl_name = args[2]
         else:
-            raise template.TemplateSyntaxError, "%r tag should have between 1 and 4 arguments" % (tokens[0],)
+            raise template.TemplateSyntaxError("%r tag should have between 1 and 4 arguments" % (tokens[0],))
         # Check to see if the slug is properly double/single quoted
         if not (self.slug[0] == self.slug[-1] and self.slug[0] in ('"', "'")):
             self.is_variable = True

--- a/mezzanine_blocks/views.py
+++ b/mezzanine_blocks/views.py
@@ -2,8 +2,8 @@ from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext
 from django.http import HttpResponseRedirect, HttpResponseForbidden, HttpResponse
 from django.utils.translation import ugettext as _
-from models import Block
-from forms import BlockForm
+from .models import Block
+from .forms import BlockForm
 
 def edit(request, pk, modelform_class=BlockForm, permission_check=None, template_name='mezzanine_blocks/edit.html', success_url=None):
     """


### PR DESCRIPTION
Hey,

There are couple of minor fixes that could make mezzanine-blocks run with Python3.3.

Didn't test for all use cases, but this seems to work initially.
