### PR TITLE
Fix django.core.exceptions.AppRegistryNotReady in defaults.py

### DIFF
--- a/mezzanine_blocks/defaults.py
+++ b/mezzanine_blocks/defaults.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from mezzanine.conf import register_setting
 
 


### PR DESCRIPTION
Fixes AppRegistryNotReady for Django 1.7
